### PR TITLE
Upgrade javac to 1.6 in ant build.xml

### DIFF
--- a/utilities/build.xml
+++ b/utilities/build.xml
@@ -28,7 +28,7 @@
 		
 		<mkdir dir="${project.release.distrib.dir}/classes"/>
 		<javac 
-			target="1.5"
+			target="1.6"
 			classpathref="project.classpath"
 			destdir="${project.release.distrib.dir}/classes">
 			<src path="${project.src.dir}"/>


### PR DESCRIPTION
Ant 1.10.5 said that "Source option 5 is no longer supported".
Just upgrade javac to target="1.6" in build.xml to meet the minimum requirement of ant.

```
$ cd iperf-jperf/utilities
$ ant release
Buildfile: /tmp/iperf-jperf/utilities/build.xml

release:
    [mkdir] Created dir: /tmp/iperf-jperf/release/jperf-2.0.2
     [copy] Copying 3 files to /tmp/iperf-jperf/release/jperf-2.0.2
    [mkdir] Created dir: /tmp/iperf-jperf/release/jperf-2.0.2/classes
    [javac] /tmp/iperf-jperf/utilities/build.xml:33: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 18 source files to /tmp/iperf-jperf/release/jperf-2.0.2/classes
    [javac]
    [javac]           WARNING
    [javac]
    [javac] The -source switch defaults to 9 in JDK 9.
    [javac] If you specify -target 1.5 you now must also specify -source 1.5.
    [javac] Ant will implicitly add -source 1.5 for you.  Please change your build file.
    [javac] warning: [options] bootstrap class path not set in conjunction with -source 5
    [javac] error: Source option 5 is no longer supported. Use 6 or later.
    [javac] error: Target option 1.5 is no longer supported. Use 1.6 or later.

BUILD FAILED
/tmp/iperf-jperf/utilities/build.xml:33: Compile failed; see the compiler error output for details.

Total time: 0 seconds
```

$ javac -version
javac 11.0.3

$ ant -version
Apache Ant(TM) version 1.10.5 compiled on March 28 2019

Signed-off-by: Liu Qun <517067180@qq.com>